### PR TITLE
Update PR video workflow to use TypeScript render script

### DIFF
--- a/.github/workflows/pr-video-on-merge.yml
+++ b/.github/workflows/pr-video-on-merge.yml
@@ -77,7 +77,7 @@ jobs:
           -e VIDEO_TYPE=${{ steps.params.outputs.video_type }} \
           -e OUTPUT_NAME=${{ steps.params.outputs.output_name }} \
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main \
-          node render-pr-video.mjs
+          npx tsx render-pr-video.ts
 
     - name: List generated files
       run: ls -la ./output/


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use the TypeScript version of the render script with tsx instead of the JavaScript version. This resolves module resolution issues and provides better type safety.